### PR TITLE
feat: add GitHub Actions workflow for building Windows executable

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,36 @@
+name: Build Windows Executable
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Python
+      uses: actions/setup-python@v3
+      with:
+        python-version: '3.10'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+        pip install pyinstaller
+
+    - name: Build executable with PyInstaller
+      run: |
+        pyinstaller --onefile --windowed src/app.py
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: windows-exe
+        path: dist/*.exe


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to build a Windows executable for the application. The workflow is triggered by pushes and pull requests to the `main` branch, as well as manually via `workflow_dispatch`.

Key changes include:

* [`.github/workflows/build.yaml`](diffhunk://#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1R1-R36): Added a new workflow named "Build Windows Executable" which sets up a Windows environment, installs Python and necessary dependencies, builds the executable using PyInstaller, and uploads the resulting executable as an artifact.